### PR TITLE
feat: 将抓包数据保存在单独的文件中避免每次都要重新抓包

### DIFF
--- a/.github/workflows/GenerateCaptureLogKey.go
+++ b/.github/workflows/GenerateCaptureLogKey.go
@@ -9,9 +9,8 @@ import (
 	"os"
 )
 
-// main 函数在 `go generate` 时被调用
 func main() {
-	// AES-256 需要一个 32 字节的密钥
+	// AES-256 使用 32 字节的密钥
 	key := make([]byte, 32)
 	if _, err := rand.Read(key); err != nil {
 		fmt.Fprintf(os.Stderr, "错误: 无法生成随机密钥: %v\n", err)

--- a/.github/workflows/GenerateCaptureLogKey.go
+++ b/.github/workflows/GenerateCaptureLogKey.go
@@ -1,0 +1,29 @@
+//go:build generate
+// +build generate
+
+package main
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+)
+
+// main 函数在 `go generate` 时被调用
+func main() {
+	// AES-256 需要一个 32 字节的密钥
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		fmt.Fprintf(os.Stderr, "错误: 无法生成随机密钥: %v\n", err)
+		os.Exit(1)
+	}
+
+	// fmt.Println(key)
+	err := os.WriteFile("encrypt/capture.log.key", key, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "错误: 无法写入 capture.log.key: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("成功生成并保存了新的 AES 密钥到 capture.log.key。")
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,23 +48,17 @@ jobs:
       - name: Zip the folder
         run: powershell Compress-Archive -Path gf2gacha -DestinationPath gf2gacha.zip
 
-#      - name: Upload to R2
-#        uses: ryand56/r2-upload-action@latest
-#        with:
-#          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
-#          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
-#          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-#          r2-bucket: ${{ secrets.R2_BUCKET }}
-#          source-dir: |
-#            build/bin/gf2gacha.exe
-#            gf2gacha.zip
-#          destination-dir: gf2gacha/${{ github.ref_name }}/
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload to R2
+        uses: ryand56/r2-upload-action@latest
         with:
-          name: gf2gacha.zip
-          path: gf2gacha.exe
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ secrets.R2_BUCKET }}
+          source-dir: |
+            build/bin/gf2gacha.exe
+            gf2gacha.zip
+          destination-dir: gf2gacha/${{ github.ref_name }}/
 
       - name: Upload Release Asset
         uses: ncipollo/release-action@v1
@@ -73,7 +67,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
 
-#      - name: Build Changelog
-#        run: npx changelogithub
-#        env:
-#          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Build Changelog
+        run: npx changelogithub
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,24 +48,18 @@ jobs:
       - name: Zip the folder
         run: powershell Compress-Archive -Path gf2gacha -DestinationPath gf2gacha.zip
 
-      # - name: Build Changelog
-      #   run: npx changelogithub
-      #   env:
-      #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload to R2
+        uses: ryand56/r2-upload-action@latest
         with:
-          name: gf2gacha.zip
-          path: gf2gacha.exe
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ secrets.R2_BUCKET }}
+          source-dir: |
+            build/bin/gf2gacha.exe
+            gf2gacha.zip
+          destination-dir: gf2gacha/${{ github.ref_name }}/
 
-      # softprops/action-gh-release有问题（详见其Issues），暂时改用ncipollo/release-action
-      # - name: Upload Release Asset
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     files: |
-      #       gf2gacha.zip
-      #       gf2gacha.exe
       - name: Upload Release Asset
         uses: ncipollo/release-action@v1
         with:
@@ -73,14 +67,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
 
-      # - name: Upload to R2
-      #   uses: ryand56/r2-upload-action@latest
-      #   with:
-      #     r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
-      #     r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
-      #     r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      #     r2-bucket: ${{ secrets.R2_BUCKET }}
-      #     source-dir: |
-      #       build/bin/gf2gacha.exe
-      #       gf2gacha.zip
-      #     destination-dir: gf2gacha/${{ github.ref_name }}/
+      - name: Build Changelog
+        run: npx changelogithub
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,13 +57,21 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: gf2gacha.zip
-          path: gf2gacha.zip
+          path: gf2gacha.exe
 
+      # softprops/action-gh-release有问题（详见其Issues），暂时改用ncipollo/release-action
+      # - name: Upload Release Asset
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     files: |
+      #       gf2gacha.zip
+      #       gf2gacha.exe
       - name: Upload Release Asset
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
-          files:
-            gf2gacha.exe
+          artifacts: "gf2gacha.zip,gf2gacha.exe"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
 
       # - name: Upload to R2
       #   uses: ryand56/r2-upload-action@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,17 +48,23 @@ jobs:
       - name: Zip the folder
         run: powershell Compress-Archive -Path gf2gacha -DestinationPath gf2gacha.zip
 
-      - name: Upload to R2
-        uses: ryand56/r2-upload-action@latest
+#      - name: Upload to R2
+#        uses: ryand56/r2-upload-action@latest
+#        with:
+#          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+#          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+#          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+#          r2-bucket: ${{ secrets.R2_BUCKET }}
+#          source-dir: |
+#            build/bin/gf2gacha.exe
+#            gf2gacha.zip
+#          destination-dir: gf2gacha/${{ github.ref_name }}/
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
         with:
-          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          r2-bucket: ${{ secrets.R2_BUCKET }}
-          source-dir: |
-            build/bin/gf2gacha.exe
-            gf2gacha.zip
-          destination-dir: gf2gacha/${{ github.ref_name }}/
+          name: gf2gacha.zip
+          path: gf2gacha.exe
 
       - name: Upload Release Asset
         uses: ncipollo/release-action@v1
@@ -67,7 +73,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
 
-      - name: Build Changelog
-        run: npx changelogithub
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+#      - name: Build Changelog
+#        run: npx changelogithub
+#        env:
+#          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,30 @@ jobs:
           (Get-Content "util/Version.go") -replace 'const version = ""', 'const version = "${{ github.ref_name }}"' | Set-Content "util/Version.go"
           (Get-Content "wails.json") -replace '"productVersion": ""', '"productVersion": "${{ github.ref_name }}"' | Set-Content "wails.json"
 
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Setup GoLang
         uses: actions/setup-go@v5
         with:
           check-latest: true
           go-version: 1.23
+
+      - name: Cache Node modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
@@ -35,7 +54,9 @@ jobs:
 
       - name: Build App
         working-directory: .
-        run: wails build -webview2 embed -skipbindings -o gf2gacha.exe
+        run: |
+          go generate ./...
+          wails build -webview2 embed -skipbindings -o gf2gacha.exe
 
       - name: Create folder and copy files
         run: |
@@ -46,17 +67,10 @@ jobs:
       - name: Zip the folder
         run: powershell Compress-Archive -Path gf2gacha -DestinationPath gf2gacha.zip
 
-      - name: Upload to R2
-        uses: ryand56/r2-upload-action@latest
-        with:
-          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          r2-bucket: ${{ secrets.R2_BUCKET }}
-          source-dir: |
-            build/bin/gf2gacha.exe
-            gf2gacha.zip
-          destination-dir: gf2gacha/${{ github.ref_name }}/
+      # - name: Build Changelog
+      #   run: npx changelogithub
+      #   env:
+      #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v2
@@ -64,9 +78,15 @@ jobs:
           files: |
             gf2gacha.zip
             gf2gacha.exe
-      
 
-      - name: Build Changelog
-        run: npx changelogithub
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      # - name: Upload to R2
+      #   uses: ryand56/r2-upload-action@latest
+      #   with:
+      #     r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+      #     r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+      #     r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      #     r2-bucket: ${{ secrets.R2_BUCKET }}
+      #     source-dir: |
+      #       build/bin/gf2gacha.exe
+      #       gf2gacha.zip
+      #     destination-dir: gf2gacha/${{ github.ref_name }}/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,7 @@ jobs:
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            gf2gacha.zip
+          files:
             gf2gacha.exe
 
       # - name: Upload to R2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,30 +19,11 @@ jobs:
           (Get-Content "util/Version.go") -replace 'const version = ""', 'const version = "${{ github.ref_name }}"' | Set-Content "util/Version.go"
           (Get-Content "wails.json") -replace '"productVersion": ""', '"productVersion": "${{ github.ref_name }}"' | Set-Content "wails.json"
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Setup GoLang
         uses: actions/setup-go@v5
         with:
           check-latest: true
           go-version: 1.23
-
-      - name: Cache Node modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3
@@ -71,6 +52,12 @@ jobs:
       #   run: npx changelogithub
       #   env:
       #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gf2gacha.zip
+          path: gf2gacha.zip
 
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v2

--- a/app.go
+++ b/app.go
@@ -7,6 +7,7 @@ import (
 	"gf2gacha/logger"
 	"gf2gacha/logic"
 	"gf2gacha/model"
+	"gf2gacha/request"
 	"gf2gacha/util"
 	"github.com/elazarl/goproxy"
 	"github.com/pkg/errors"
@@ -227,6 +228,11 @@ func (a *App) ExportMccExcel(uid string) (message string, err error) {
 func (a *App) HandleCommunityTasks() (messageList []string, err error) {
 	messageList, err = logic.HandleCommunityTasks()
 	if err != nil {
+		var respData request.CommonResponse
+		if errors.As(err, &respData) && respData.Code == 401 {
+			logger.Logger.Error(err)
+			return nil, errors.New("Token失效，请重新捕获")
+		}
 		logger.Logger.Error(err)
 		return
 	}

--- a/app.go
+++ b/app.go
@@ -382,7 +382,7 @@ func (a *App) CaptureStart() error {
 
 			logger.Logger.Infof("uid: %d\n", userInfo.User.GameUid)
 			logger.Logger.Infof("gachaUrl: %s\n", gachaUrl)
-			logger.Logger.Infof("accessToken: %s\n", accessToken)
+			//logger.Logger.Infof("accessToken: %s\n", accessToken)
 
 			runtime.EventsEmit(a.ctx, "captureSuccess")
 		}

--- a/encrypt/EmbedKey.go
+++ b/encrypt/EmbedKey.go
@@ -1,0 +1,6 @@
+package encrypt
+
+import _ "embed"
+
+//go:embed capture.log.key
+var AesKey []byte

--- a/encrypt/LogEncryptor.go
+++ b/encrypt/LogEncryptor.go
@@ -1,0 +1,60 @@
+package encrypt
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+// 使用 AES-GCM 加密数据
+func Encrypt(plaintext []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	// Seal 函数会处理加密和认证，并将 nonce 附加到密文的开头。
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	return ciphertext, nil
+}
+
+// 使用 AES-GCM 解密数据
+func Decrypt(ciphertext []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, fmt.Errorf("密文太短")
+	}
+
+	// 从密文中分离 nonce 和实际的加密数据
+	nonce, actualCiphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+
+	// Open 函数会验证认证标签并解密
+	plaintext, err := gcm.Open(nil, nonce, actualCiphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("解密失败: %w", err)
+	}
+
+	return plaintext, nil
+}

--- a/logic/AppendLog.go
+++ b/logic/AppendLog.go
@@ -1,34 +1,33 @@
 package logic
 
 import (
+	_ "embed"
 	"fmt"
-	"github.com/pkg/errors"
+	"gf2gacha/encrypt"
 	"os"
 	"path/filepath"
 )
 
 func AppendLog(accessToken string, uid int64, gachaUrl string) error {
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	logPath := filepath.Join(userHome, "/AppData/LocalLow/SunBorn/少女前线2：追放/Player.log")
-	file, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND, 0644)
+	logPath := filepath.Join("./capture.log")
+	file, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 
-	_, err = file.WriteString(fmt.Sprintf(`{"access_token":"%s","uid":%d}\n`, accessToken, uid))
+	// 加密数据
+	aesKey := encrypt.AesKey
+	plainData := fmt.Sprintf(`{"access_token":"%s","uid":%d,"gacha_record_url":"%s"}`, accessToken, uid, gachaUrl)
+	encryptedData, err := encrypt.Encrypt([]byte(plainData), aesKey)
 	if err != nil {
 		return err
 	}
 
-	_, err = file.WriteString(fmt.Sprintf(`{"gacha_record_url":"%s"}\n`, gachaUrl))
+	// 写入加密数据
+	err = os.WriteFile(logPath, encryptedData, 0644);
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"gf2gacha/logger"
 	_ "gf2gacha/logger"
 	"gf2gacha/util"
+
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
@@ -13,6 +14,8 @@ import (
 
 //go:embed all:frontend/dist
 var assets embed.FS
+
+//go:generate go run .github/workflows/GenerateCaptureLogKey.go
 
 func main() {
 	defer logger.Logger.Sync()

--- a/util/GetLogInfo.go
+++ b/util/GetLogInfo.go
@@ -36,10 +36,9 @@ func GetLogInfo() (logInfo model.LogInfo, err error) {
 	aesKey := encrypt.AesKey
 	captureLogData, err := encrypt.Decrypt(captureLogEncrypt, aesKey)
 	if err != nil {
-		fmt.Printf("解密文件时出错: %v\n", err)
-		os.Exit(1)
+		fmt.Printf("%v\n", err)
+		return model.LogInfo{}, errors.New("解密capture.log失败，请尝试重新捕获")
 	}
-	fmt.Printf("captureLogData: %v\n", captureLogData)
 	logData = append(logData, captureLogData...)
 
 	regexpGamePath, err := regexp.Compile(`\[Subsystems] Discovering subsystems at path (.+)/UnitySubsystems`)

--- a/util/GetLogInfo.go
+++ b/util/GetLogInfo.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"gf2gacha/encrypt"
 	"gf2gacha/model"
 	"github.com/pkg/errors"
 	"os"
@@ -19,6 +21,26 @@ func GetLogInfo() (logInfo model.LogInfo, err error) {
 	if err != nil {
 		return model.LogInfo{}, errors.WithStack(err)
 	}
+
+	// logData补充读取./capture.log
+	captureLogPath := filepath.Join("./capture.log")
+	captureLogEncrypt, err := os.ReadFile(captureLogPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return model.LogInfo{}, errors.New("未找到捕获记录capture.log，官服请使用「捕获信息」按钮抓包")
+		} else {
+			return model.LogInfo{}, errors.WithStack(err)
+		}
+	}
+	// 进行解密
+	aesKey := encrypt.AesKey
+	captureLogData, err := encrypt.Decrypt(captureLogEncrypt, aesKey)
+	if err != nil {
+		fmt.Printf("解密文件时出错: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("captureLogData: %v\n", captureLogData)
+	logData = append(logData, captureLogData...)
 
 	regexpGamePath, err := regexp.Compile(`\[Subsystems] Discovering subsystems at path (.+)/UnitySubsystems`)
 	if err != nil {


### PR DESCRIPTION
> Player.log 会被清空，每天签到都要重新抓包还是太麻烦了

1. 将抓包数据保存在 ./capture.log 中，为了安全性对 ./capture.log 进行了加密
   - [GenerateCaptureLogKey.go](.github/workflows/GenerateCaptureLogKey.go) y用于在 Actions 构建时使用`go generate ./...`生成 AES 密钥
   - [EmbedKey.go](encrypt/EmbedKey.go) 用于嵌入该密钥
   - [LogEncryptor.go](encrypt/LogEncryptor.go) 用于加密和解密 capture.log

2. Actions 的上传到 Release 改用`ncipollo/release-action`，原`softprops/action-gh-release`看起来暂时[有问题](https://github.com/softprops/action-gh-release/issues/628)